### PR TITLE
Add mounted_on field to output records

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Or install it yourself as:
 
 ## Output Format
 
-    2013-03-01 00:00:00 +0900 df._dev_disk0s2: {"size":"487546976","used":"52533512","available":"434757464","capacity":"11","hostname":"my.local"}
+    2013-03-01 00:00:00 +0900 df._dev_disk0s2: {"size":"487546976","used":"52533512","available":"434757464","capacity":"11","hostname":"my.local", "mounted_on":"/"}
 
   If `tag` specified, character of `tag` is the Tag name.
 

--- a/lib/fluent/plugin/in_df.rb
+++ b/lib/fluent/plugin/in_df.rb
@@ -56,7 +56,8 @@ module Fluent
           'size'      => f[1],
           'used'      => f[2],
           'available' => f[3],
-          'capacity'  => f[4] && @rm_percent ? f[4].delete('%') : f[4]
+          'capacity'  => f[4] && @rm_percent ? f[4].delete('%') : f[4],
+          'mounted_on' => f[5]
         }
         df_info['hostname'] = `hostname`.chomp if @hostname
         df_info


### PR DESCRIPTION
I added mounted_on field to output records to distinguish each disk volume by mount point name, not only by filesystem name.
I think it's useful when we specify multiple target_mount parameters and get multiple records.
