### PR TITLE
[fix] Use router.emit instead of Engine.emit

### DIFF
--- a/lib/fluent/plugin/in_df.rb
+++ b/lib/fluent/plugin/in_df.rb
@@ -74,7 +74,7 @@ module Fluent
     def watch
       df.each do |result|
         fs = result.delete('fs')
-        Fluent::Engine.emit(tag_name(fs), Fluent::Engine.now, result)
+        router.emit(tag_name(fs), Fluent::Engine.now, result)
       end
     end
   end


### PR DESCRIPTION
Fix the following issue regarding to the below:
* http://www.fluentd.org/blog/fluentd-v0.14.0-has-been-released
* https://github.com/fluent/fluentd/issues/1041